### PR TITLE
feat: add "iconv-lite" into bundle

### DIFF
--- a/.yarn/versions/b18f68b3.yml
+++ b/.yarn/versions/b18f68b3.yml
@@ -1,0 +1,4 @@
+releases:
+  "@react-thermal-printer/image": minor
+  "@react-thermal-printer/printer": minor
+  react-thermal-printer: minor

--- a/example/package.json
+++ b/example/package.json
@@ -2,7 +2,9 @@
   "name": "react-thermal-printer-exmaple",
   "private": true,
   "scripts": {
-    "dev": "vite dev"
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -42,6 +42,8 @@ export function App() {
 
   const [port, setPort] = useState<SerialPort>();
   const print = async () => {
+    const data = await render(receipt);
+
     let _port = port;
     if (_port == null) {
       _port = await navigator.serial.requestPort();
@@ -51,7 +53,6 @@ export function App() {
 
     const writer = _port.writable?.getWriter();
     if (writer != null) {
-      const data = await render(receipt);
       await writer.write(data);
       writer.releaseLock();
     }

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -14,9 +14,9 @@
     "import": "./dist/index.mjs",
     "exports": {
       ".": {
+        "types": "./dist/index.d.ts",
         "require": "./dist/index.js",
-        "import": "./dist/index.mjs",
-        "types": "./dist/index.d.ts"
+        "import": "./dist/index.mjs"
       }
     }
   },

--- a/packages/printer/package.json
+++ b/packages/printer/package.json
@@ -14,9 +14,9 @@
     "import": "./dist/index.mjs",
     "exports": {
       ".": {
+        "types": "./dist/index.d.ts",
         "require": "./dist/index.js",
-        "import": "./dist/index.mjs",
-        "types": "./dist/index.d.ts"
+        "import": "./dist/index.mjs"
       }
     }
   },
@@ -29,7 +29,9 @@
     "build": "tsup"
   },
   "dependencies": {
-    "@react-thermal-printer/image": "workspace:^",
+    "@react-thermal-printer/image": "workspace:^"
+  },
+  "devDependencies": {
     "iconv-lite": "^0.6.3",
     "tsup": "^8.3.0"
   }

--- a/packages/printer/tsup.config.ts
+++ b/packages/printer/tsup.config.ts
@@ -9,4 +9,5 @@ export default defineConfig({
   target: 'es2020',
   platform: 'neutral',
   bundle: true,
+  noExternal: ['iconv-lite'],
 });

--- a/packages/react-thermal-printer/package.json
+++ b/packages/react-thermal-printer/package.json
@@ -13,9 +13,9 @@
     "import": "./dist/index.mjs",
     "exports": {
       ".": {
+        "types": "./dist/index.d.ts",
         "require": "./dist/index.js",
-        "import": "./dist/index.mjs",
-        "types": "./dist/index.d.ts"
+        "import": "./dist/index.mjs"
       }
     }
   },


### PR DESCRIPTION
Libraries such as safe-buffer (used in iconv-lite) require some transpiling to operate properly in the browser.

Since most modern bundlers do not transpile packages located in `node_modules/` (e.g. next.js), problems may occur when running in the browser.

To solve this, transpile iconv-lite in advance and include it in the bundle. 