### PR TITLE
feat: improve wrapText to support word-level wrapping (#81)

### DIFF
--- a/.yarn/versions/3798b153.yml
+++ b/.yarn/versions/3798b153.yml
@@ -1,0 +1,2 @@
+releases:
+  "@react-thermal-printer/printer": patch

--- a/packages/printer/src/Printer.ts
+++ b/packages/printer/src/Printer.ts
@@ -5,6 +5,7 @@ export type Align = 'left' | 'center' | 'right';
 export type TextFont = 'A' | 'B' | 'C' | 'D' | 'E' | 'special-A' | 'special-B';
 export type TextSize = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
 export type TextUnderline = '1dot-thick' | '2dot-thick' | 'none';
+export type TextWordBreak = 'break-all' | 'break-word';
 export interface QRCodeOptions {
   /** @default model2 */
   model?: 'model1' | 'model2' | 'micro';

--- a/packages/react-thermal-printer/src/components/Row.tsx
+++ b/packages/react-thermal-printer/src/components/Row.tsx
@@ -56,6 +56,7 @@ Row.print = (elem, context) => {
   const leftString = reactNodeToString(leftElem.props.children);
   const leftSize = leftElem.props.size?.width;
   const leftLength = textLength(leftString, { size: leftSize });
+  const leftWordBreak = leftElem.props.wordBreak;
 
   const centerString = centerElem !== undefined ? reactNodeToString(centerElem.props.children) : undefined;
   const centerSize = centerElem?.props.size?.width;
@@ -63,11 +64,13 @@ Row.print = (elem, context) => {
   const rightString = reactNodeToString(rightElem.props.children);
   const rightSize = rightElem.props.size?.width;
   const rightLength = textLength(rightString, { size: rightSize });
+  const rightWordBreak = rightElem.props.wordBreak;
 
   const leftLineWidth = centerElem !== undefined ? leftLength : width - gap - rightLength;
   const leftLines = wrapText(leftString, {
     size: leftSize,
     width: leftLineWidth,
+    wordBreak: leftWordBreak,
   });
   const centerLineWidth = width - Math.max(gap * 2, 1) - leftLength - rightLength;
   const centerLines =
@@ -76,6 +79,7 @@ Row.print = (elem, context) => {
   const rightLines = wrapText(rightString, {
     size: rightSize,
     width: rightLineWidth,
+    wordBreak: rightWordBreak,
   });
 
   const maxLines = Math.max(leftLines.length, centerLines?.length ?? 0, rightLines.length);

--- a/packages/react-thermal-printer/src/components/Text.tsx
+++ b/packages/react-thermal-printer/src/components/Text.tsx
@@ -14,6 +14,7 @@ type Props = ExtendHTMLProps<
     underline?: TextUnderline;
     invert?: boolean;
     size?: { width: TextSize; height: TextSize };
+    wordBreak?: 'break-all' | 'break-word';
     /** if true, don't feed line after print text */
     inline?: boolean;
     children?: ReactNode;
@@ -28,6 +29,7 @@ export const Text: Printable<Props> = ({
   invert,
   size,
   inline,
+  wordBreak,
   className,
   children,
   ...props
@@ -42,6 +44,7 @@ export const Text: Printable<Props> = ({
       data-size-width={size?.width}
       data-size-height={size?.height}
       data-inline={inline}
+      data-word-break={wordBreak}
       className={classNames('rtp-text', className)}
       {...props}
     >

--- a/packages/react-thermal-printer/src/utils/wrapText.spec.ts
+++ b/packages/react-thermal-printer/src/utils/wrapText.spec.ts
@@ -14,3 +14,18 @@ it('fix invalid count value error for wrong input', () => {
 
   expect(wrapText(text, { width: -1 })).toEqual(['', 't', 'e', 's', 't']);
 });
+
+it('wraps text with break-word strategy', () => {
+  const text = '안녕하세요 반갑습니다 자나깨나 불조심 꺼진불도 다시보자';
+
+  expect(wrapText(text, { width: 8, wordBreak: 'break-word' })).toEqual([
+    '안녕하세',
+    '요      ',
+    '반갑습니',
+    '다      ',
+    '자나깨나',
+    '불조심  ',
+    '꺼진불도',
+    '다시보자',
+  ]);
+});


### PR DESCRIPTION
I made text look better when it prints on receipt paper! before, texts would break in the middle of words. I added a new option called "break-word" that keeps words together.

this means:
- if a word is too big for one line, it moves to the next line
- text looks neater and easier to read

can you please review my code?