### PR TITLE
chore: update ESC/POS reference links to new Epson publication URLs

### DIFF
--- a/.yarn/versions/0fc4a992.yml
+++ b/.yarn/versions/0fc4a992.yml
@@ -1,0 +1,2 @@
+declined:
+  - "@react-thermal-printer/printer"

--- a/packages/printer/src/commands/alignment.ts
+++ b/packages/printer/src/commands/alignment.ts
@@ -8,7 +8,7 @@ import { ESC } from './common';
  * | Hex     | 1B 61 n  |
  * | Decimal | 27 97 n  |
  *
- * @see https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=58
+ * @see https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/esc_la.html
  */
 export function alignment(n: number) {
   return [ESC, 0x61, n];

--- a/packages/printer/src/commands/barcodeHRIFont.ts
+++ b/packages/printer/src/commands/barcodeHRIFont.ts
@@ -18,7 +18,7 @@ import { GS } from './common';
  * | 97    | Special A                        |
  * | 98    | Special B                        |
  *
- * @see https://www.epson-biz.com/modules/ref_escpos/index.php?content_id=126
+ * @see https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/gs_lf.html
  */
 export function barcodeHRIFont(n: number) {
   return [GS, 0x66, n];

--- a/packages/printer/src/commands/barcodeHRIPosition.ts
+++ b/packages/printer/src/commands/barcodeHRIPosition.ts
@@ -16,7 +16,7 @@ import { GS } from './common';
  * | 3, 51 | Both above and below the barcode |
  *
  * @default n = 0
- * @see https://www.epson-biz.com/modules/ref_escpos/index.php?content_id=125
+ * @see https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/gs_ch.html
  */
 export function barcodeHRIPosition(n = 0) {
   return [GS, 0x48, n];

--- a/packages/printer/src/commands/barcodeHeight.ts
+++ b/packages/printer/src/commands/barcodeHeight.ts
@@ -8,7 +8,7 @@ import { GS } from './common';
  * | Hex     | 1D  68   n |
  * | Decimal | 29 104   n |
  *
- * @see https://www.epson-biz.com/modules/ref_escpos/index.php?content_id=127
+ * @see https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/gs_lh.html
  */
 export function barcodeHeight(n: number) {
   return [GS, 0x68, n];

--- a/packages/printer/src/commands/barcodePrint.ts
+++ b/packages/printer/src/commands/barcodePrint.ts
@@ -8,7 +8,7 @@ import { GS } from './common';
  * | Hex     | 1D  6B   m   n   d1...dn |
  * | Decimal | 29 107   m   n   d1...dn |
  *
- * @see https://www.epson-biz.com/modules/ref_escpos/index.php?content_id=128
+ * @see https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/gs_lk.html
  */
 export function barcodePrint(m: number, n: number, data: ArrayLike<number>) {
   const base = [GS, 0x6b, m, n];

--- a/packages/printer/src/commands/barcodeWidth.ts
+++ b/packages/printer/src/commands/barcodeWidth.ts
@@ -8,7 +8,7 @@ import { GS } from './common';
  * | Hex     | 1D  77   n |
  * | Decimal | 29 119   n |
  *
- * @see https://www.epson-biz.com/modules/ref_escpos/index.php?content_id=129
+ * @see https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/gs_lw.html
  */
 export function barcodeWidth(n: number) {
   return [GS, 0x77, n];

--- a/packages/printer/src/commands/cashdraw.ts
+++ b/packages/printer/src/commands/cashdraw.ts
@@ -8,7 +8,7 @@ import { ESC } from './common';
  * | Hex     |  1B  70   m  t1   t2 |
  * | Decimal |  27  27   m  t1   t2 |
  *
- * @see https://www.epson-biz.com/modules/ref_escpos/index.php?content_id=195
+ * @see https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/esc_lp.html
  */
 export function cashdraw(m: number, t1: number, t2: number) {
   return [ESC, 0x70, m, t1, t2];

--- a/packages/printer/src/commands/characterCodeTable.ts
+++ b/packages/printer/src/commands/characterCodeTable.ts
@@ -8,7 +8,7 @@ import { ESC } from './common';
  * | Hex     | 1B 74 n   |
  * | Decimal | 27 116 n  |
  *
- * @see https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=32
+ * @see https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/esc_lt.html
  */
 export function characterCodeTable(n: number) {
   return [ESC, 0x74, n];

--- a/packages/printer/src/commands/cut.ts
+++ b/packages/printer/src/commands/cut.ts
@@ -16,7 +16,7 @@ import { GS } from './common';
  * | Hex     | 1D 56 m n |
  * | Decimal | 29 86 m n |
  *
- * @see https://www.epson-biz.com/modules/ref_escpos/index.php?content_id=87
+ * @see https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/gs_cv.html
  */
 export function cut(m: number, n?: number) {
   const cmd = [GS, 0x56, m];

--- a/packages/printer/src/commands/image.ts
+++ b/packages/printer/src/commands/image.ts
@@ -8,7 +8,7 @@ import { GS } from './common';
  * | Hex     | 1D 76 30 m xL xH yL yH d1...dk  |
  * | Decimal | 29 118 48 m xL xH yL yH d1...dk |
  *
- * @see https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=94
+ * @see https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/gs_lv_0.html
  */
 export function image(m: number, xL: number, xH: number, yL: number, yH: number, data: ArrayLike<number>) {
   const base = [GS, 0x76, 0x30, m, xL, xH, yL, yH];

--- a/packages/printer/src/commands/initialize.ts
+++ b/packages/printer/src/commands/initialize.ts
@@ -8,7 +8,7 @@ import { ESC } from './common';
  * | Hex     | 1B 40   |
  * | Decimal | 27 64   |
  *
- * @see https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=192
+ * @see https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/esc_atsign.html
  */
 export function initialize() {
   return [ESC, 0x40];

--- a/packages/printer/src/commands/internationalCharacterSet.ts
+++ b/packages/printer/src/commands/internationalCharacterSet.ts
@@ -8,7 +8,7 @@ import { ESC } from './common';
  * | Hex     | 1B 52 n  |
  * | Decimal | 27 82 n  |
  *
- * @see https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=29
+ * @see https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/esc_cr.html
  */
 export function internationalCharacterSet(n: number) {
   return [ESC, 0x52, n];

--- a/packages/printer/src/commands/invert.ts
+++ b/packages/printer/src/commands/invert.ts
@@ -1,14 +1,14 @@
 import { GS } from './common';
 
 /**
- * Specify/cancel white/black inverted printing
+ * Turn white/black reverse print mode on/off
  * | Format   | Value    |
  * |---------|----------|
  * | ASCII   | GS b n   |
  * | Hex     | 1D 42 n  |
  * | Decimal | 29 66 n  |
  *
- * @see https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=25
+ * @see https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/gs_cb.html
  */
 export function invert(n: number) {
   return [GS, 0x42, n];

--- a/packages/printer/src/commands/qrcodeCellSize.ts
+++ b/packages/printer/src/commands/qrcodeCellSize.ts
@@ -8,7 +8,7 @@ import { GS } from './common';
  * | Hex     | 1D  28  6B  03  00  31  43  n |
  * | Decimal | 29  40 107   3   0  49  67  n |
  *
- * @see https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=141
+ * @see https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/gs_lparen_lk_fn167.html
  */
 export function qrcodeCellSize(n: number) {
   return [GS, 0x28, 0x6b, 0x03, 0x00, 0x31, 0x43, n];

--- a/packages/printer/src/commands/qrcodeCorrectionLevel.ts
+++ b/packages/printer/src/commands/qrcodeCorrectionLevel.ts
@@ -9,7 +9,7 @@ import { GS } from './common';
  * | Decimal | 29  40 107   0   0  49  69  n |
  *
  * @default n = 48
- * @see https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=142
+ * @see https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/gs_lparen_lk_fn169.html
  */
 export function qrcodeCorrectionLevel(n = 48) {
   return [GS, 0x28, 0x6b, 0x03, 0x00, 0x31, 0x45, n];

--- a/packages/printer/src/commands/qrcodeModel.ts
+++ b/packages/printer/src/commands/qrcodeModel.ts
@@ -9,7 +9,7 @@ import { GS } from './common';
  * | Decimal | 29  40 107   4   0  49  65  n1  n2 |
  *
  * @default n1=50, n2=0
- * @see https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=140
+ * @see https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/gs_lparen_lk_fn165.html
  */
 export function qrcodeModel(n1 = 50, n2 = 0) {
   return [GS, 0x28, 0x6b, 0x04, 0x00, 0x31, 0x41, n1, n2];

--- a/packages/printer/src/commands/qrcodePrint.ts
+++ b/packages/printer/src/commands/qrcodePrint.ts
@@ -8,7 +8,7 @@ import { GS } from './common';
  * | Hex     | 1D  28  6B  03  00  31  51  m |
  * | Decimal | 29  40 107   3   0  49  81  m |
  *
- * @see https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=144
+ * @see https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/gs_lparen_lk_fn181.html
  */
 export function qrcodePrint() {
   return [GS, 0x28, 0x6b, 0x03, 0x00, 0x31, 0x51, 48];

--- a/packages/printer/src/commands/qrcodeStore.ts
+++ b/packages/printer/src/commands/qrcodeStore.ts
@@ -8,7 +8,7 @@ import { GS } from './common';
  * | Hex     | 1D  28  6B  pL  pH  31  50  30  d1...dk |
  * | Decimal | 29  40 107  pL  pH  49  80  48  d1...dk |
  *
- * @see https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=143
+ * @see https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/gs_lparen_lk_fn180.html
  */
 export function qrcodeStore(pL: number, pH: number, data: ArrayLike<number>) {
   const base = [GS, 0x28, 0x6b, pL, pH, 0x31, 0x50, 0x30];

--- a/packages/printer/src/commands/textBold.ts
+++ b/packages/printer/src/commands/textBold.ts
@@ -8,7 +8,7 @@ import { ESC } from './common';
  * | Hex     | 1B 45 n  |
  * | Decimal | 27 69 n  |
  *
- * @see https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=25
+ * @see https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/esc_ce.html
  */
 export function textBold(n: number) {
   return [ESC, 0x45, n];

--- a/packages/printer/src/commands/textFont.ts
+++ b/packages/printer/src/commands/textFont.ts
@@ -8,7 +8,7 @@ import { ESC } from './common';
  * | Hex     | 1B 4D n  |
  * | Decimal | 27 7 n  |
  *
- * @see https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=27
+ * @see https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/esc_cm.html
  */
 export function textFont(n: number) {
   return [ESC, 0x4d, n];

--- a/packages/printer/src/commands/textMode.ts
+++ b/packages/printer/src/commands/textMode.ts
@@ -8,7 +8,7 @@ import { ESC } from './common';
  * | Hex     | 1B 21 n  |
  * | Decimal | 27 33 n  |
  *
- * @see https://www.epson-biz.com/modules/ref_escpos/index.php?content_id=23
+ * @see https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/esc_exclamation.html
  */
 export function textMode(n: number) {
   return [ESC, 0x21, n];

--- a/packages/printer/src/commands/textSize.ts
+++ b/packages/printer/src/commands/textSize.ts
@@ -8,7 +8,7 @@ import { GS } from './common';
  * | Hex     | 1D 21 n  |
  * | Decimal | 29 33 n  |
  *
- * @see https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=34
+ * @see https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/gs_exclamation.html
  */
 export function textSize(n: number) {
   return [GS, 0x21, n];

--- a/packages/printer/src/commands/textUnderline.ts
+++ b/packages/printer/src/commands/textUnderline.ts
@@ -8,7 +8,7 @@ import { ESC } from './common';
  * | Hex     | 1B 2D n  |
  * | Decimal | 27 45 n  |
  *
- * @see https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=24
+ * @see https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/esc_minus.html
  */
 export function textUnderline(n: number) {
   return [ESC, 0x2d, n];


### PR DESCRIPTION
updated deprecated reference links across various printer command files to point to the latest Epson ESC/POS documentation.