### PR TITLE
chore: fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ function myCustomImageReader(
 
 Apply greyscale([Floyd-Steinberg dithering](https://en.wikipedia.org/wiki/Floyd%E2%80%93Steinberg_dithering)):
 ```tsx
-import { transforms } from '@react-therma-printer/image';
+import { transforms } from '@react-thermal-printer/image';
 
 <Image src="https://my-cdn.com/image.png" transforms={[transforms.floydSteinberg]} />
 ```


### PR DESCRIPTION
I think that `@react-thermal-printer/image` is the correct spelling. (https://www.npmjs.com/package/@react-thermal-printer/image)